### PR TITLE
service: Fix `request_body` type

### DIFF
--- a/semantic_matcher/service.py
+++ b/semantic_matcher/service.py
@@ -138,7 +138,7 @@ class SemanticMatchingService:
         endpoint = config['RESOLVER']['endpoint']
         port = config['RESOLVER'].getint('port')
         url = f"{endpoint}:{port}/get_semantic_matching_service"
-        response = requests.get(url, json=request_body.dict())
+        response = requests.get(url, json=request_body)
 
         # Check if the response is successful (status code 200)
         if response.status_code == 200:


### PR DESCRIPTION
Previously, we introduced a bug where the type of
the `request_body` in the 
`_get_matcher_from_semantic_id` function was cast
to a `Dict`, while already being a `Dict`. 
This fixes this oversight by removing the cast. 
