### PR TITLE
service: Add option to modify listen address

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -1,5 +1,6 @@
 [SERVICE]
 endpoint=http://127.0.0.1
+LISTEN_ADDRESS=127.0.0.1
 port=8000
 equivalence_table_file=./resources/equivalence_table.json
 

--- a/semantic_matcher/service.py
+++ b/semantic_matcher/service.py
@@ -180,4 +180,4 @@ if __name__ == '__main__':
     APP.include_router(
         SEMANTIC_MATCHING_SERVICE.router
     )
-    uvicorn.run(APP, host="0.0.0.0", port=int(config["SERVICE"]["PORT"]))
+    uvicorn.run(APP, host=config["SERVICE"]["LISTEN_ADDRESS"], port=int(config["SERVICE"]["PORT"]))


### PR DESCRIPTION
Previously, uvicorn only listened on `0.0.0.0`, which may be a security risk in some situations.

We add a configuration option to modify the listen address via the `config.ini` and set the default to `127.0.0.1`