### PR TITLE
Fix docker container definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Alpine Linux as the base image
-FROM python:3.9-alpine
+FROM python:3.11-alpine
 
 # Install Git
 RUN apk update && apk add --no-cache git
@@ -10,11 +10,9 @@ WORKDIR /app
 # Copy the package files to the working directory
 COPY . .
 
-# Install system dependencies
-# RUN apk --no-cache add build-base libffi-dev
-
 # Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --upgrade pip
+RUN pip install .
 
 # Set PYTHONPATH to the app directory
 ENV PYTHONPATH=/app

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  semantic_matching_service:
+    build: .
+    container_name: semantic_matching_service
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    working_dir: /app/semantic_matcher
+    command: ["python", "service.py"]


### PR DESCRIPTION
After the major refactor, the Dockerfile was broken. This fixes it, and adapts it to use
Python version 3.11 at the same time (as defined in the `pyproject.toml`).

Furthermore, this adds a `compose.yaml` for easier deployment.

Sadly, however, this introduces #15, as currently we cannot run the container directly via command, as there is a broken path definition.